### PR TITLE
[magento 2.1.3] fix config.xml

### DIFF
--- a/app/code/MercadoPago/Core/etc/config.xml
+++ b/app/code/MercadoPago/Core/etc/config.xml
@@ -1,21 +1,20 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <mercadopago>
+            <country>mlb</country>
+            <title>General configuration</title>
+            <order_status_approved>processing</order_status_approved>
+            <order_status_refunded>pending</order_status_refunded>
+            <order_status_in_process>pending</order_status_in_process>
+            <order_status_in_mediation>pending</order_status_in_mediation>
+            <order_status_rejected>pending</order_status_rejected>
+            <order_status_cancelled>pending</order_status_cancelled>
+            <order_status_chargeback>pending</order_status_chargeback>
+            <logs>0</logs>
+            <debug_mode>0</debug_mode>
+            <use_successpage_mp>1</use_successpage_mp>
+        </mercadopago>
         <payment>
-            <mercadopago>
-                <country>mlb</country>
-                <title>General configuration</title>
-                <order_status_approved>processing</order_status_approved>
-                <order_status_refunded>pending</order_status_refunded>
-                <order_status_in_process>pending</order_status_in_process>
-                <order_status_in_mediation>pending</order_status_in_mediation>
-                <order_status_rejected>pending</order_status_rejected>
-                <order_status_cancelled>pending</order_status_cancelled>
-                <order_status_chargeback>pending</order_status_chargeback>
-                <logs>0</logs>
-                <debug_mode>0</debug_mode>
-                <use_successpage_mp>1</use_successpage_mp>
-            </mercadopago>
-
             <mercadopago_custom>
                 <active>0</active>
                 <useccv>1</useccv>


### PR DESCRIPTION
En Magento 2.1.3 la extensión rompe el checkout debido a un error en el archivo config.xml de la extensión Core.

El error que arroja en system.log es:

Payment model name is not provided in config!

Y es debido a que dentro del archivo config.xml el nodo:
< mercadopago >
se encuentra dentro del nodo < payment >