### PR TITLE
Fixed return value in source method to match contract

### DIFF
--- a/src/MercadoPago/MercadoEnvios/Model/System/Config/Source/Method.php
+++ b/src/MercadoPago/MercadoEnvios/Model/System/Config/Source/Method.php
@@ -52,7 +52,7 @@ class Method
         if (isset($this->_countryOptions[$country])) {
             return $this->_countryOptions[$country];
         }
-        return null;
+        return array();
     }
 
     /**


### PR DESCRIPTION
`toOptionArray` is expected to return an array (see Magento\Framework\Data\OptionSourceInterface).
Specifically, MercadoPago\MercadoEnvios\Model\System\Config\Source\FreeMethod calls `parent::toOptionArray()` and calls array_unshift() on it so it throws and error if value type is invalid.

Fixes #12