### PR TITLE
Fix de bug al realizar compras con el metodo standard

### DIFF
--- a/src/MercadoPago/Core/Model/Standard/Payment.php
+++ b/src/MercadoPago/Core/Model/Standard/Payment.php
@@ -500,4 +500,15 @@ class Payment
 
     }
 
+    /**
+     * Return success page url
+     *
+     * @return string
+     */
+    public function getOrderPlaceRedirectUrl()
+    {
+        $url = $this->_helperData->getSuccessUrl();
+
+        return $this->_urlBuilder->getUrl($url, ['_secure' => true]);
+    }
 }


### PR DESCRIPTION
Se repara un bug que hace que se envíe el mail de confirmación de compra cuando el cliente selecciona el metodo de pago en el checkout, dandole la impresión de que su pedido ya fue procesado cuando todavia ni siquiera completó los datos de compra. Esto sucede con el metodo Standard de mercadopago.