### PR TITLE
Escaped several strings according to Magento 2.2 XSS standards

### DIFF
--- a/src/MercadoPago/Core/view/frontend/templates/calculator/calculatorForm.phtml
+++ b/src/MercadoPago/Core/view/frontend/templates/calculator/calculatorForm.phtml
@@ -94,9 +94,9 @@ $isSecure = $this->isCurrentlySecure();
     </main>
 
     <script type="text/javascript">
-        var PublicKeyMercadoPagoCustom = '<?php /* @escapeNotVerified */ echo $pk; ?>';
-        var AllPaymentMethods = '<?php /* @escapeNotVerified */ echo json_encode($list); ?>';
-        var Amount = '<?php /* @escapeNotVerified */ echo $amount ?>';
+        var PublicKeyMercadoPagoCustom = '<?php echo $block->escapeJs($pk); ?>';
+        var AllPaymentMethods = '<?php /* @noEscape */ echo json_encode($list); ?>';
+        var Amount = '<?php echo $block->escapeJs($amount); ?>';
     </script>
     <script>
         require(['MPcustom', 'tinyj', 'tiny', 'meli', 'calculator'],

--- a/src/MercadoPago/Core/view/frontend/templates/custom/success.phtml
+++ b/src/MercadoPago/Core/view/frontend/templates/custom/success.phtml
@@ -7,7 +7,8 @@
     $payment = $this->getPayment();
     
     //monta link para o pedido
-$link_to_order = __('Your order %1 has been successfully generated.', '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>');
+    $link_to_order = '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>';
+    $successMsg = 'Your order %1 has been successfully generated.';
     
     $payment_method = $this->getPaymentMethod();
     $info_payment = $this->getInfoPayment();
@@ -17,7 +18,7 @@ $link_to_order = __('Your order %1 has been successfully generated.', '<a href="
 
     <?php if(!isset($info_payment['status']['value'])): ?>
         <h2 class="mercadopago-title"><?php /* @escapeNotVerified */ echo __('Thank you for your purchase!'); ?></h2>
-        <p><?php /* @escapeNotVerified */ echo $link_to_order; ?></p>
+        <p><?php /* @escapeNotVerified */ echo __($successMsg, $link_to_order); ?></p>
     <?php else: ?>
         <?php
             $message_status = $this->getMessageByStatus(
@@ -32,7 +33,7 @@ $link_to_order = __('Your order %1 has been successfully generated.', '<a href="
 
         <p><?php echo $block->escapeHtml($message_status['message']); ?></p>
 
-        <p><?php /* @escapeNotVerified */ echo $link_to_order; ?></p>
+        <p><?php /* @escapeNotVerified */ echo __($successMsg, $link_to_order); ?></p>
 
         <h3 class="mercadopago-title-info-payment"><?php /* @escapeNotVerified */ echo __('Payment information'); ?></h3>
 
@@ -49,6 +50,6 @@ $link_to_order = __('Your order %1 has been successfully generated.', '<a href="
 
 
 <div class="primary button-success">
-    <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
+    <a class="action primary continue" href="<?php echo $block->escapeUrl($block->getUrl()) ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
 </div>
 

--- a/src/MercadoPago/Core/view/frontend/templates/custom_ticket/success.phtml
+++ b/src/MercadoPago/Core/view/frontend/templates/custom_ticket/success.phtml
@@ -6,11 +6,6 @@ $order = $this->getOrder();
 $total = $this->getTotal();
 $payment = $this->getPayment();
 
-$link_to_order = __(
-    'Your order %1 has been successfully generated.',
-    '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>'
-);
-
 $payment_method = $this->getPaymentMethod();
 $info_payment = $this->getInfoPayment();
 ?>
@@ -21,7 +16,10 @@ $info_payment = $this->getInfoPayment();
         <h2 class="mercadopago-title"><?php /* @escapeNotVerified */ echo __('Thank you for your purchase!'); ?></h2>
 
         <p>
-            <?php /* @escapeNotVerified */ echo $link_to_order; ?>
+            <?php /* @escapeNotVerified */ echo __(
+                'Your order %1 has been successfully generated.',
+                '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>'
+            ); ?>
         </p>
 
         <p>
@@ -43,5 +41,5 @@ $info_payment = $this->getInfoPayment();
 </div>
 
 <div class="primary button-success">
-    <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
+    <a class="action primary continue" href="<?php echo $block->escapeUrl($block->getUrl()) ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
 </div>

--- a/src/MercadoPago/Core/view/frontend/templates/standard/success.phtml
+++ b/src/MercadoPago/Core/view/frontend/templates/standard/success.phtml
@@ -7,10 +7,8 @@ $order = $this->getOrder();
 $total = $this->getTotal();
 $payment = $this->getPayment();
 
-$linkToOrder = __(
-    'Your order %1 has been successfully generated.',
-    '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>'
-);
+$successMsg = 'Your order %1 has been successfully generated.';
+$linkToOrder = '<a href="' . $block->escapeUrl($this->getOrderUrl()) . '">' . $block->escapeHtml($order->getIncrementId()) . '</a>';
 
 $paymenMethod = $this->getPaymentMethod();
 $infoPayment = $this->getInfoPayment();
@@ -21,7 +19,7 @@ $infoPayment = $this->getInfoPayment();
     <?php if (!isset($infoPayment['status']['value'])): ?>
         <h2 class="mercadopago-title">
             <?php /* @escapeNotVerified */ echo __('Thank you for your purchase!'); ?>
-        </h2><p><?php /* @escapeNotVerified */ echo $linkToOrder; ?></p>
+        </h2><p><?php /* @escapeNotVerified */ echo __($successMsg, $linkToOrder); ?></p>
     <?php else: ?><?php
         $message_status = $this->getMessageByStatus(
             (isset($infoPayment['status']['value'])?$infoPayment['status']['value']:''),
@@ -35,7 +33,7 @@ $infoPayment = $this->getInfoPayment();
 
         <p><?php echo $block->escapeHtml($message_status['message']); ?></p>
 
-        <p><?php /* @escapeNotVerified */ echo $linkToOrder; ?></p>
+        <p><?php /* @escapeNotVerified */ echo __($successMsg, $linkToOrder); ?></p>
 
         <h3 class="mercadopago-title-info-payment"><?php /* @escapeNotVerified */ echo __('Payment information'); ?></h3>
 
@@ -53,6 +51,6 @@ $infoPayment = $this->getInfoPayment();
 
 
     <div class="primary button-success">
-        <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
+        <a class="action primary continue" href="<?php echo $block->escapeUrl($block->getUrl()) ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
     </div>
 

--- a/src/MercadoPago/MercadoEnvios/view/adminhtml/templates/array_dropdown.phtml
+++ b/src/MercadoPago/MercadoEnvios/view/adminhtml/templates/array_dropdown.phtml
@@ -25,7 +25,7 @@ $prevValues = $block->_getStoredMappingValues();
         <?php foreach($meCode as $key => $meOption):?>
             <tr id="<?php /* @noEscape */ echo $meOption ?>">
                     <td>
-                        <label><?php /* @escapeNotVerified */ echo $meLabel[$key] ?>:</label>
+                        <label><?php echo $block->escapeHtml($meLabel[$key]) ?>:</label>
                     </td>
                     <td>
                         <select name="groups[mercadoenvios][fields][attributesmapping][value][<?php /* @noEscape */ echo $meOption ?>][attribute_code]">


### PR DESCRIPTION
Magento 2.2 Templates XSS Standard no longer accepts `@escapeNotVerified` when there is an appropiate escaping function.

This PR replaces several instances of `@escapeNotVerified` with the corresponding `escapeXyz()` function of the `@noEscape` annotation