### PR TITLE
Some defensive programming in ConfigurationObserver

### DIFF
--- a/src/MercadoPago/Core/Lib/Api.php
+++ b/src/MercadoPago/Core/Lib/Api.php
@@ -86,6 +86,9 @@ class Api {
 
     /**
      * Get Access Token for API use
+     *
+     * @return mixed
+     * @throws \Exception
      */
     public function get_access_token() {
         if (isset ($this->ll_access_token) && !is_null($this->ll_access_token)) {
@@ -331,6 +334,7 @@ class Api {
      * @param uri
      * @param data
      * @param params
+     * @throws \Exception
      */
     public function post($uri, $data, $params = null) {
         $params = is_array ($params) ? $params : array();

--- a/src/MercadoPago/Core/Observer/ConfigObserver.php
+++ b/src/MercadoPago/Core/Observer/ConfigObserver.php
@@ -370,6 +370,9 @@ class ConfigObserver
 
     }
 
+    /**
+     * @param \MercadoPago\Core\Lib\Api $api
+     */
     protected function sendAnalyticsData($api)
     {
         $request = [
@@ -412,8 +415,13 @@ class ConfigObserver
         $request['data']['checkout_custom_ticket_coupon'] = $customTicketCoupon == 1 ? 'true' : 'false';
 
         $this->coreHelper->log("Analytics settings request sent /modules/tracking/settings", self::LOG_NAME, $request);
-        $response = $api->post("/modules/tracking/settings", $request['data']);
-        $this->coreHelper->log("Analytics settings response", self::LOG_NAME, $response);
+
+        try {
+            $response = $api->post("/modules/tracking/settings", $request['data']);
+            $this->coreHelper->log("Analytics settings response", self::LOG_NAME, $response);
+        } catch (\Exception $exception) {
+            $this->coreHelper->log("Exception thrown on Analytics request", self::LOG_NAME, $exception->getMessage());
+        }
 
     }
 }


### PR DESCRIPTION
Added try-catch block in config observer to prevent configuration saving errors when MP API credentials are not set

Fixes #38