### PR TITLE
Disable MercadoEnvios by default

### DIFF
--- a/src/MercadoPago/MercadoEnvios/etc/config.xml
+++ b/src/MercadoPago/MercadoEnvios/etc/config.xml
@@ -2,7 +2,7 @@
     <default>
         <carriers>
             <mercadoenvios>
-                <active>1</active>
+                <active>0</active>
                 <title>MercadoEnvíos</title>
                 <model>MercadoPago\MercadoEnvios\Model\Carrier\MercadoEnvios</model>
                 <sort_order>10</sort_order>


### PR DESCRIPTION
Changed `config.xml` so that MercadoEnvios is not enabled by default as is the best practices recommendation for any module and prevents errors during deployment and testing by preserving the expected default Magento application behavior at those stages