### PR TITLE
Não funciona mais no Magento 2.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/694b7584dbdf471f2e13/maintainability)](https://codeclimate.com/github/mercadopago/cart-magento2/maintainability)
 
 ![Mercado Pago](https://raw.githubusercontent.com/mercadopago/cart-magento2/master/README.img/logo_mp.png)
+
+CADE?


### PR DESCRIPTION
Alguma coisa mudou?
Cade a documentação...
Sem atualização do modulo parou de funcionar.
![image](https://user-images.githubusercontent.com/12032611/53092219-f645a480-34f2-11e9-9020-6557ddc739de.png)

404 em /static/version****/frontend/***/***/pt_BR/transparent.js
![image](https://user-images.githubusercontent.com/12032611/53092288-20976200-34f3-11e9-8b7e-c22812625806.png)
