### PR TITLE
CSRF validation en notifications

### DIFF
--- a/src/MercadoPago/Core/Controller/Notifications/AbstractNotification.php
+++ b/src/MercadoPago/Core/Controller/Notifications/AbstractNotification.php
@@ -1,0 +1,25 @@
+<?php
+namespace MercadoPago\Core\Controller\Notifications;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+
+/**
+ * Class Standard
+ *
+ * @package MercadoPago\Core\Controller\Notifications
+ */
+abstract class AbstractNotification extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+{
+    public function createCsrfValidationException(
+        RequestInterface $request
+    ): ?InvalidRequestException {
+        return null;
+    }
+    
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        return true;
+    }
+}

--- a/src/MercadoPago/Core/Controller/Notifications/Custom.php
+++ b/src/MercadoPago/Core/Controller/Notifications/Custom.php
@@ -7,8 +7,7 @@ namespace MercadoPago\Core\Controller\Notifications;
  *
  * @package MercadoPago\Core\Controller\Notifications
  */
-class Custom
-    extends \Magento\Framework\App\Action\Action
+class Custom extends AbstractNotification
 
 {
     /**

--- a/src/MercadoPago/Core/Controller/Notifications/Standard.php
+++ b/src/MercadoPago/Core/Controller/Notifications/Standard.php
@@ -6,8 +6,7 @@ namespace MercadoPago\Core\Controller\Notifications;
  *
  * @package MercadoPago\Core\Controller\Notifications
  */
-class Standard
-    extends \Magento\Framework\App\Action\Action
+class Standard extends AbstractNotification
 
 {
     /**


### PR DESCRIPTION
Hola. Los POSTs a _notifications_ generan 302 redirects porque les falta el csrf token, lo no permite que se reciban las confirmaciones de pago. Con estos dos métodos en Custom.php y Standard.php se puede obviar ese chequeo.

Espero les sirva.