### PR TITLE
Fix Preference/Basic.php payer info bug

### DIFF
--- a/src/MercadoPago/Core/Model/Preference/Basic.php
+++ b/src/MercadoPago/Core/Model/Preference/Basic.php
@@ -469,7 +469,7 @@ class Basic extends AbstractMethod
             }
 
             $test_mode = true;
-            if (!empty($sponsor_id) && strpos(payerInfo['email'], "@testuser.com") === false) {
+            if (!empty($sponsor_id) && strpos($payerInfo['email'], "@testuser.com") === false) {
                 $arr['sponsor_id'] = (int)$sponsor_id;
                 $test_mode = false;
             }


### PR DESCRIPTION
In the latest version of the module when a user tries to continue to Mercado Pago payment gateway it throws an error.

There seems to be a typo where the `payerInfo` variable is missing the `$`.