### PR TITLE
[HOTFIX] prevenir problemas con HTTP POST en 2.3.x

### DIFF
--- a/src/MercadoPago/Core/Plugin/CsrfValidatorSkip.php
+++ b/src/MercadoPago/Core/Plugin/CsrfValidatorSkip.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace MercadoPago\Core\Plugin;
+
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\Request\CsrfValidator;
+use Magento\Framework\App\RequestInterface;
+
+class CsrfValidatorSkip
+{
+
+    /**
+     * @param \Magento\Framework\App\Request\CsrfValidator $subject
+     * @param callable $proceed
+     * @param RequestInterface $request
+     * @param ActionInterface $action
+     * @return void
+     */
+    public function aroundValidate(\Magento\Framework\App\Request\CsrfValidator $subject, callable $proceed, RequestInterface $request, ActionInterface $action)
+    {
+        if ($request->getModuleName() == 'mercadopago') {
+            return; // Skip CSRF check
+        }
+        return $proceed($request, $action);
+    }
+}

--- a/src/MercadoPago/Core/etc/di.xml
+++ b/src/MercadoPago/Core/etc/di.xml
@@ -35,4 +35,8 @@
     <type name="Magento\Framework\View\Asset\Minification">
         <plugin name="mercadopago_minification_plugin" type="MercadoPago\Core\Plugin\MinificationIsExcludedPlugin"/>
     </type>
+
+    <type name="Magento\Framework\App\Request\CsrfValidator">
+        <plugin name="csrf_validator_skip" type="MercadoPago\Core\Plugin\CsrfValidatorSkip" />
+    </type>
 </config>


### PR DESCRIPTION
Magento en la version 2.3.x agrego un control que toda llamdas de frontend controller tienen que gener el FORM KEY. En el modulo de mercado pago cuando se llama a la notificaciones no estan funcionando por este motivo.

Mas informacion https://magento.stackexchange.com/questions/253414/magento-2-3-upgrade-breaks-http-post-requests-to-custom-module-endpoint

Para Prevenir este problema (por ahora) es evitar ese control con el Plugin propuesta en PR.
La solucion final es que toda comunicacion que tengan que hacer con Magento las hagan por REST API y cambiar en notification callback url.

Slds,
Alejandro.