### PR TITLE
fix empty array on mercado pago success page

### DIFF
--- a/src/MercadoPago/Core/Controller/Checkout/Page.php
+++ b/src/MercadoPago/Core/Controller/Checkout/Page.php
@@ -140,7 +140,9 @@ class Page
 
             } else {
                 //set data for mp analytics
-                $this->_catalogSession->setPaymentData($this->_helperData->getAnalyticsData($this->_getOrder()));
+                $analyticsData = $this->_helperData->getAnalyticsData($this->_getOrder());
+                $analyticsData = array_merge($analyticsData, $this->getRequest()->getParams());
+                $this->_catalogSession->setPaymentData($analyticsData);
                 $checkoutTypeHandle = $this->getCheckoutHandle();
                 $this->_view->loadLayout(['default', $checkoutTypeHandle]);
                 $this->dispatchSuccessActionObserver();

--- a/src/MercadoPago/Core/Helper/Data.php
+++ b/src/MercadoPago/Core/Helper/Data.php
@@ -440,8 +440,8 @@ class Data
                 $methodCode = $order->getPayment()->getData('method');
                 $analyticsData = [
                     'payment_id' => $this->getPaymentId($additionalInfo),
-                    'payment_type' => $additionalInfo['payment_method_id'],
-                    'checkout_type' => $additionalInfo['method'],
+                    'payment_type' => isset($additionalInfo['payment_method_id']) ? $additionalInfo['payment_method_id'] : "",
+                    'checkout_type' => isset($additionalInfo['method']) ? $additionalInfo['method'] : "",
                     'analytics_key' => $this->getClientIdFromAccessToken($accessToken)
                 ];
                 if ($methodCode == \MercadoPago\Core\Model\Custom\Payment::CODE) {


### PR DESCRIPTION
Cuando es usado mecardo pago de forma externa y regresa a la pagina de exito a veces se rompe porque envian mal los parametros, y genera un array vacio.