### PR TITLE
Marked credentials as sensitive configuration

### DIFF
--- a/src/MercadoPago/Core/etc/di.xml
+++ b/src/MercadoPago/Core/etc/di.xml
@@ -43,4 +43,14 @@
     <type name="Magento\Framework\App\Request\CsrfValidator">
         <plugin name="csrf_validator_skip" type="MercadoPago\Core\Plugin\CsrfValidatorSkip"/>
     </type>
+
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="payment/mercadopago/public_key" xsi:type="string">1</item>
+                <item name="payment/mercadopago/access_token" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Marked public_key and access_token as sensitive configuration to avoid revealing when running app:config:dump in Magento deployment pipeline

See https://devdocs.magento.com/cloud/live/sens-data-over.html#sensitive-data