### PR TITLE
hotfix: link ticket options labels to they radio buttons

### DIFF
--- a/src/MercadoPago/Core/view/frontend/web/template/payment/custom_ticket.html
+++ b/src/MercadoPago/Core/view/frontend/web/template/payment/custom_ticket.html
@@ -41,20 +41,32 @@
                     <!-- ko foreach: {data: getTicketsData(), as: 'ticket'} -->
                     <!-- ko if: (ticket.payment_places.length === 0) -->
                     <li style="display:inline-block; width: 40%; vertical-align: top;" class="mercadopago-ticket-option">
-                        <input type="radio" class="optionsTicketMp" name="mercadopago_custom_ticket[payment_method_ticket]" data-bind="'attr':{ value: ticket.id, 'data-validate': JSON.stringify({ 'validate-one-required-by-name':true })}" />
-                        <label class="mercadopago-ticket-label">
+                        <input type="radio" class="optionsTicketMp" name="mercadopago_custom_ticket[payment_method_ticket]" data-bind="'attr':{
+                            value: ticket.id,
+                            id: `mp-ticket-input-${ticket.name.replace(/ /d, '-').replace(/\W/g, '').toLowerCase()}`,
+                            'data-validate': JSON.stringify({ 'validate-one-required-by-name':true })
+                        }" />
+                        <label class="mercadopago-ticket-label" data-bind="attr:{
+                            for:`mp-ticket-input-${ticket.name.replace(/ /d, '-').replace(/\W/g, '').toLowerCase()}`
+                        }">
                             <img data-bind="'attr':{src: ticket.secure_thumbnail, alt: ticket.name}" />
-                            <label class="mercadopago-ticket-label" data-bind="text: ticket.name"></label>
+                            <span class="mercadopago-ticket-label" data-bind="text: ticket.name"></span>
                         </label>
                     </li>
                     <!--/ko-->
                     <!-- ko if: (ticket.payment_places.length > 0) -->
                     <!-- ko foreach: {data: ticket.payment_places, as: 'payment_place'} -->
                     <li style="display:inline-block;  width: 40%; vertical-align: top;" class="mercadopago-ticket-option">
-                        <input type="radio" class="optionsTicketMp" name="mercadopago_custom_ticket[payment_method_ticket]" data-bind="'attr':{ value: (ticket.id + '|' + payment_place.payment_option_id), 'data-validate': JSON.stringify({ 'validate-one-required-by-name':true })}" />
-                        <label class="mercadopago-ticket-label">
+                        <input type="radio" class="optionsTicketMp" name="mercadopago_custom_ticket[payment_method_ticket]" data-bind="'attr':{
+                            value: (ticket.id + '|' + payment_place.payment_option_id),
+                            id: `mp-ticket-input-${ticket.name.replace(/ /d, '-').replace(/\W/g, '').toLowerCase()}`,
+                            'data-validate': JSON.stringify({ 'validate-one-required-by-name':true })
+                        }" />
+                        <label class="mercadopago-ticket-label" data-bind="attr:{
+                            for:`mp-ticket-input-${ticket.name.replace(/ /d, '-').replace(/\W/g, '').toLowerCase()}`
+                        }">
                             <img data-bind="'attr':{src: payment_place.thumbnail, alt: payment_place.name}" />
-                            <label class="mercadopago-ticket-label" data-bind="text: payment_place.name"></label>
+                            <span class="mercadopago-ticket-label" data-bind="text: payment_place.name"></span>
                         </label>
                     </li>
                     <!--/ko-->


### PR DESCRIPTION
This links the "choose payment place" labels to their respective radio buttons, allowing to click on them to select an option.

![image](https://user-images.githubusercontent.com/4603111/151616562-1b42eec2-8d63-42a7-b3fb-48f59810f4e3.png)
> The labels above are now clickable (not needing to click on the radio buttons themselves like before).
